### PR TITLE
Fix provider_id parameter for list-templates

### DIFF
--- a/provision-vm-service/list-templates.asl
+++ b/provision-vm-service/list-templates.asl
@@ -11,7 +11,7 @@
         "api_password": "$.api_password"
       },
       "Parameters": {
-        "provider_id": "$.attrs.dialog_provider"
+        "provider_id": "$.dialog_provider"
       }
     }
   }


### PR DESCRIPTION
The list-templates workflow wasn't updated for how the dialog values are passed causing the provider_id to always be `nil`

`INFO -- workflows: Running state: [ListTemplates] with input [{"dialog"=>{"dialog_vm_name"=>"", "dialog_provider"=>3, "dialog_template"=>0}}]...Complete - next state: [] output: [{"provider_id"=>nil, "values"=>{}}]`