### PR TITLE
Fix provider_id under `$.dialog.`

### DIFF
--- a/provision-vm-service/list-templates.asl
+++ b/provision-vm-service/list-templates.asl
@@ -11,7 +11,7 @@
         "api_password": "$.api_password"
       },
       "Parameters": {
-        "provider_id": "$.dialog_provider"
+        "provider_id": "$.dialog.dialog_provider"
       }
     }
   }


### PR DESCRIPTION
I missed that `dialog_provider` was under a top-level `"dialog"` key, we might want to fix this in core depending on if there is anything interesting at the top level besides dialog but this fixes the workflow for now

`INFO -- workflows: Running state: [ListTemplates] with input [{"dialog"=>{"dialog_vm_name"=>"", "dialog_provider"=>3, "dialog_template"=>0}}]...Complete - next state: [] output: [{"provider_id"=>nil, "values"=>{}}]`