### PR TITLE
Don't verify manageiq api peer certificate

### DIFF
--- a/provision-vm-service/clone-template/clone-template.rb
+++ b/provision-vm-service/clone-template/clone-template.rb
@@ -10,6 +10,7 @@ api_user     = secrets.fetch("api_user", "admin")
 api_password = secrets.fetch("api_password", "smartvm")
 
 api_url      = ENV.fetch("API_URL", "http://localhost:3000")
+verify_ssl   = ENV.fetch("VERIFY_SSL", "true") == "true"
 ems_id       = ENV.fetch("PROVIDER_ID")
 template_ref = ENV.fetch("TEMPLATE")
 folder_ref   = ENV.fetch("FOLDER", nil)
@@ -18,7 +19,7 @@ pool_ref     = ENV.fetch("RESPOOL", nil)
 vm_name      = ENV.fetch("NAME")
 
 require "manageiq-api-client"
-api = ManageIQ::API::Client.new(:url => api_url, :user => api_user, :password => api_password)
+api = ManageIQ::API::Client.new(:url => api_url, :user => api_user, :password => api_password, :ssl => {:verify => verify_ssl})
 
 vcenter_host = api.providers.pluck(:id, :hostname).detect { |id, _| id == ems_id }.last
 

--- a/provision-vm-service/list-providers.asl
+++ b/provision-vm-service/list-providers.asl
@@ -11,7 +11,8 @@
         "api_password.$": "$.api_password"
       },
       "Parameters": {
-        "PROVIDER_TYPE.$": "ManageIQ::Providers::Vmware::InfraManager"
+        "PROVIDER_TYPE.$": "ManageIQ::Providers::Vmware::InfraManager",
+        "VERIFY_SSL": false
       }
     }
   }

--- a/provision-vm-service/list-providers/list-providers.rb
+++ b/provision-vm-service/list-providers/list-providers.rb
@@ -9,8 +9,14 @@ password = secrets.fetch("api_password", "smartvm")
 
 url           = ENV.fetch("API_URL", "http://localhost:3000")
 provider_type = ENV.fetch("PROVIDER_TYPE", nil)
+verify_ssl    = ENV.fetch("VERIFY_SSL", "true") == "true"
 
-api = ManageIQ::API::Client.new(:url => url, :user => user, :password => password)
+api = ManageIQ::API::Client.new(
+  :url      => url,
+  :user     => user,
+  :password => password,
+  :ssl      => {:verify => verify_ssl}
+)
 
 response = api.providers
 response = response.where(:type => provider_type) if provider_type

--- a/provision-vm-service/list-templates.asl
+++ b/provision-vm-service/list-templates.asl
@@ -11,7 +11,8 @@
         "api_password.$": "$.api_password"
       },
       "Parameters": {
-        "PROVIDER_ID.$": "$.dialog.dialog_provider"
+        "PROVIDER_ID.$": "$.dialog.dialog_provider",
+        "VERIFY_SSL": false
       }
     }
   }

--- a/provision-vm-service/list-templates/list-templates.rb
+++ b/provision-vm-service/list-templates/list-templates.rb
@@ -7,10 +7,16 @@ secrets = JSON.load(File.read(ENV.fetch("SECRETS")))
 api_user     = secrets.fetch("api_user", "admin")
 api_password = secrets.fetch("api_password", "smartvm")
 
-api_url = ENV.fetch("API_URL", "http://localhost:3000")
-ems_id  = ENV.fetch("PROVIDER_ID")
+api_url    = ENV.fetch("API_URL", "http://localhost:3000")
+ems_id     = ENV.fetch("PROVIDER_ID")
+verify_ssl = ENV.fetch("VERIFY_SSL", "true") == "true"
 
-api = ManageIQ::API::Client.new(:url => api_url, :user => api_user, :password => api_password)
+api = ManageIQ::API::Client.new(
+  :url      => url,
+  :user     => user,
+  :password => password,
+  :ssl      => {:verify => verify_ssl}
+)
 
 resources = api.templates.where(:ems_id => ems_id).pluck(:ems_ref, :name)
 

--- a/provision-vm-service/provision-vm.asl
+++ b/provision-vm-service/provision-vm.asl
@@ -14,6 +14,7 @@
       },
       "Parameters": {
         "PROVIDER_ID.$": "$.dialog_provider",
+        "VERIFY_SSL": false,
         "TEMPLATE.$": "$.dialog_source_template",
         "NAME.$": "$.dialog_vm_name"
       }


### PR DESCRIPTION
This fixes SSL verification errors if you point to a production appliance or podified installation rather than localhost:3000