### PR TITLE
Fix list-templates url/user/password variables

### DIFF
--- a/provision-vm-service/list-templates/list-templates.rb
+++ b/provision-vm-service/list-templates/list-templates.rb
@@ -12,9 +12,9 @@ ems_id     = ENV.fetch("PROVIDER_ID")
 verify_ssl = ENV.fetch("VERIFY_SSL", "true") == "true"
 
 api = ManageIQ::API::Client.new(
-  :url      => url,
-  :user     => user,
-  :password => password,
+  :url      => api_url,
+  :user     => api_user,
+  :password => api_password,
   :ssl      => {:verify => verify_ssl}
 )
 


### PR DESCRIPTION
I normalized the payload and variable names across the images of these attributes but forgot to change the variable names in the rest of the usages in this image.